### PR TITLE
Stateful compare fix

### DIFF
--- a/include/flat_map.hpp
+++ b/include/flat_map.hpp
@@ -22,7 +22,7 @@ class flat_map_base
     D* self() { return static_cast<D*>(this); }
 public:
     using value_compare = first_compare<value_type, Compare>;
-    value_compare value_comp() const { return value_compare(); }
+    value_compare value_comp() const { return value_compare(B::key_comp()); }
 
     using B::insert;
     using B::erase;

--- a/include/impl/flat_impl.hpp
+++ b/include/impl/flat_impl.hpp
@@ -120,24 +120,28 @@ public:
 template<typename Pair, typename Compare = std::less<void>>
 struct first_compare
 {
+	first_compare(const Compare& comp) :
+		compare(comp) {
+	}
+
     bool operator()(Pair const& lhs, Pair const& rhs) const
     {
-        return compare(lhs.first, rhs.first);
+        return compare.get()(lhs.first, rhs.first);
     }
 
     bool operator()(typename Pair::first_type const& lhs,
                     Pair const& rhs) const
     {
-        return compare(lhs, rhs.first);
+        return compare.get()(lhs, rhs.first);
     }
 
     bool operator()(Pair const& lhs,
                     typename Pair::first_type const& rhs) const
     {
-        return compare(lhs.first, rhs);
+        return compare.get()(lhs.first, rhs);
     }
 
-    Compare compare;
+    std::reference_wrapper<const Compare> compare;
 };
 
 template<typename D, typename Key,
@@ -150,7 +154,7 @@ class flat_container_base
     D* self() { return static_cast<D*>(this); }
 public:
     using key_compare = Compare;
-    key_compare key_comp() const { return self()->comp; }
+    const key_compare &key_comp() const { return self()->comp; }
 
     // Iterators
 


### PR DESCRIPTION
Pass the base constructed compare as a ref through the first compare wrapper, allowing for stateful compare objects work when they do not have a default constructor